### PR TITLE
Rename crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "cql2-rs"
+name = "cql2"
 version = "0.1.0"
 dependencies = [
  "boon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cql2-rs"
+name = "cql2"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use cql2_rs::parse;
+use cql2::parse;
 use std::io::{self, BufRead};
 fn main() -> io::Result<()> {
     for line in io::stdin().lock().lines() {

--- a/tests/ogc_tests.rs
+++ b/tests/ogc_tests.rs
@@ -1,4 +1,4 @@
-use cql2_rs::{parse, Validator};
+use cql2::{parse, Validator};
 use rstest::rstest;
 use std::fs;
 use std::path::PathBuf;
@@ -8,7 +8,7 @@ pub fn validate_file(f: &str) {
     println!("File Path: {:#?}", f);
     let cql2 = fs::read_to_string(f).unwrap();
     println!("CQL2: {}", cql2);
-    let expr: cql2_rs::Expr = parse(&cql2);
+    let expr: cql2::Expr = parse(&cql2);
     println!("Expr: {}", expr.as_json_pretty());
     let valid = expr.validate();
     assert!(valid)


### PR DESCRIPTION
In my experience, crates generally don't include the `-rs` prefix, since we assume they're the Rust version of whatever you're doing. There's not clear guidance that I can point to (and in fact there's [confusion around the topic of naming in general](https://github.com/rust-lang/api-guidelines/discussions/29)) but at least to me, `use cql2` feel better than `use cql2_rs`.
