### PR TITLE
"Libify" the Validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -626,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,9 @@ rstest = "0.21.0"
 serde = "1.0.204"
 serde_derive = "1.0.204"
 serde_json = "1.0.120"
+thiserror = "1.0.63"
+
+[[bin]]
+name = "cql2"
+test = false
+doc = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,37 @@
-use cql2::parse;
-use std::io::{self, BufRead};
-fn main() -> io::Result<()> {
-    for line in io::stdin().lock().lines() {
-        let parsed = parse(&line?);
+use cql2::Validator;
+use std::io::BufRead;
 
+fn main() {
+    let debug_level: u8 = std::env::var("CQL2_DEBUG_LEVEL")
+        .map(|s| {
+            s.parse()
+                .unwrap_or_else(|_| panic!("CQL2_DEBUG_LEVEL should be an integer: {}", s))
+        })
+        .unwrap_or(1);
+    let validator = Validator::new().unwrap();
+
+    let mut ok = true;
+    for line in std::io::stdin().lock().lines() {
+        let parsed = cql2::parse(&line.unwrap());
         println!("Parsed: {:#?}", &parsed);
-        println!("{}", parsed.as_json());
+        println!("{}", parsed.to_json().unwrap());
+        let value = serde_json::to_value(parsed).unwrap();
 
-        parsed.validate();
+        if let Err(err) = validator.validate(&value) {
+            match debug_level {
+                0 => println!("-----------\nCQL2 Is Invalid!\n---------------"),
+                1 => println!("-----------\n{err}\n---------------"),
+                2 => println!("-----------\n{err:#}\n---------------"),
+                _ => {
+                    let detailed_output = err.detailed_output();
+                    println!("-----------\n{detailed_output:#}\n---------------");
+                }
+            }
+            ok = false;
+        }
     }
-    Ok(())
+
+    if !ok {
+        std::process::exit(1);
+    }
 }

--- a/tests/ogc_tests.rs
+++ b/tests/ogc_tests.rs
@@ -1,25 +1,19 @@
-use cql2::{parse, Validator};
+use cql2::{parse, Expr, Validator};
 use rstest::rstest;
 use std::fs;
 use std::path::PathBuf;
 
 pub fn validate_file(f: &str) {
-    //println!("Current Directory: {:#?}", env::current_dir());
     println!("File Path: {:#?}", f);
     let cql2 = fs::read_to_string(f).unwrap();
     println!("CQL2: {}", cql2);
-    let expr: cql2::Expr = parse(&cql2);
-    println!("Expr: {}", expr.as_json_pretty());
-    let valid = expr.validate();
-    assert!(valid)
-}
+    let expr: Expr = parse(&cql2);
+    println!("Expr: {}", expr.to_json_pretty().unwrap());
 
-#[rstest]
-fn json_examples_are_valid(#[files("tests/fixtures/json/*.json")] path: PathBuf) {
-    let cql2 = fs::read_to_string(path).unwrap();
-    let validator = Validator::new();
-    let result = validator.validate_str(&cql2);
-    assert!(result)
+    Validator::new()
+        .unwrap()
+        .validate(&expr.to_value().unwrap())
+        .unwrap();
 }
 
 #[rstest]


### PR DESCRIPTION
## What I am changing

At a high level, moves the "how debuggy are we" logic to the binary instead of the lib, and tweaks some lib method

- Returns `Result<()>` instead of bool
- Removes `validate_str`, because it doesn't play nice with returning a `ValidationError`
- Adds crate-specific `Error` based on [thiserror](https://docs.rs/thiserror/latest/thiserror/), enabling fewer unwraps in the library
- Adds some doctests
- Disables tests and docs for the binary

## Related Issues

- Will need to be tweaked after #3 is merged to un-break the doctests
