### PR TITLE
More docs, clean up public api

### DIFF
--- a/src/bin/cql2text.rs
+++ b/src/bin/cql2text.rs
@@ -2,5 +2,5 @@ use cql2::parse_stdin;
 
 fn main() {
     let parsed = parse_stdin();
-    println!("{}", parsed.as_cql2_text());
+    println!("{}", parsed.to_cql2_text());
 }

--- a/tests/ogc_tests.rs
+++ b/tests/ogc_tests.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 pub fn validate_str(cql2: &str) {
     println!("CQL2: {}", cql2);
     let expr: cql2::Expr = parse(cql2);
-    let outcql2: String = expr.as_cql2_text();
+    let outcql2: String = expr.to_cql2_text();
     println!("Out CQL2: {}", outcql2);
     println!("Expr:  {}", expr.to_json().unwrap());
     let valid = expr.is_valid();


### PR DESCRIPTION
## What I am changing

- Rename `as_cql2_text` to `to_cql2_text` for `Expr`
- Add more docstrings
- Remove some helper functions from the public API
- Add `parse_json` and `parse_text` to the public API
- Relax the argument to `parse_file` to `impl AsRef<Path>`

I've held off on some more return-Result-instead-of-unwrapping fixes for now, I'll open a follow-on PR with those once this one lands — this one touched enough stuff I thought it best to keep 'em separate.