### PR TITLE
Add top level crate to default-members

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
       - name: cargo check
         run: cargo check
       - name: cargo test
-        run: cargo test --package cql2
+        run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ assert-json-diff = "2"
 rstest = "0.23"
 
 [workspace]
-default-members = ["cli"]
+default-members = [".", "cli"]
 members = ["cli"]


### PR DESCRIPTION
This gets `cargo test` running everything again. My bad.