### PR TITLE
Add two more static python methods

### DIFF
--- a/python/cql2.pyi
+++ b/python/cql2.pyi
@@ -26,6 +26,42 @@ class Expr:
             >>> expr = Expr.from_path("fixtures/text/example01.txt")
         """
 
+    @staticmethod
+    def parse_text(s: str) -> Expr:
+        """Parses cql2-text.
+
+        Args:
+            s (str): The cql2-text
+
+        Returns:
+            Expr: The CQL2 expression
+
+        Raises:
+            ParseError: Raised if the string does not parse as cql2-text
+
+        Examples:
+            >>> from cql2 import Expr
+            >>> expr = Expr.parse_text("landsat:scene_id = 'LC82030282019133LGN00'")
+        """
+
+    @staticmethod
+    def parse_json(s: str) -> Expr:
+        """Parses cql2-json.
+
+        Args:
+            s (str): The cql2-json string
+
+        Returns:
+            Expr: The CQL2 expression
+
+        Raises:
+            ParseError: Raised if the string does not parse as cql2-json
+
+        Examples:
+            >>> from cql2 import Expr
+            >>> expr = Expr.parse_json('{"op":"=","args":[{"property":"landsat:scene_id"},"LC82030282019133LGN00"]}')
+        """
+
     def __init__(self, cql2: str | dict[str, Any]) -> None:
         """A CQL2 expression.
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -6,6 +6,7 @@ use pyo3::{
 use std::path::PathBuf;
 
 create_exception!(cql2, ValidationError, PyException);
+create_exception!(cql2, ParseError, PyException);
 
 /// Crate-specific error enum.
 enum Error {
@@ -36,6 +37,22 @@ impl Expr {
     #[staticmethod]
     fn from_path(path: PathBuf) -> Result<Expr> {
         ::cql2::parse_file(path).map(Expr).map_err(Error::from)
+    }
+
+    /// Parses a CQL2 expression from json.
+    #[staticmethod]
+    fn parse_json(s: &str) -> PyResult<Expr> {
+        ::cql2::parse_json(s)
+            .map(Expr)
+            .map_err(|err| ParseError::new_err(err.to_string()))
+    }
+
+    /// Parses a CQL2 expression from text.
+    #[staticmethod]
+    fn parse_text(s: &str) -> PyResult<Expr> {
+        ::cql2::parse_text(s)
+            .map(Expr)
+            .map_err(|err| ParseError::new_err(err.to_string()))
     }
 
     /// Parses a CQL2 expression.
@@ -137,6 +154,7 @@ fn cql2(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Expr>()?;
     m.add_class::<SqlQuery>()?;
     m.add_function(wrap_pyfunction!(main, m)?)?;
+    m.add("ParseError", py.get_type_bound::<ParseError>())?;
     m.add("ValidationError", py.get_type_bound::<ValidationError>())?;
     Ok(())
 }

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -1,7 +1,9 @@
+import json
 from pathlib import Path
+from typing import Any
 
 import pytest
-from cql2 import Expr, ValidationError
+from cql2 import Expr, ParseError, ValidationError
 
 
 def test_from_path(fixtures: Path) -> None:
@@ -16,6 +18,18 @@ def test_init(example01_text: str) -> None:
     Expr(example01_text)
 
 
+def test_parse_json(example01_text: str, example01_json: dict[str, Any]) -> None:
+    Expr.parse_json(json.dumps(example01_json))
+    with pytest.raises(ParseError):
+        Expr.parse_json(example01_text)
+
+
+def test_parse_text(example01_text: str, example01_json: dict[str, Any]) -> None:
+    Expr.parse_text(example01_text)
+    with pytest.raises(ParseError):
+        Expr.parse_text(json.dumps(example01_json))
+
+
 def test_to_json(example01_text: str) -> None:
     Expr(example01_text).to_json() == {
         "op": "=",
@@ -23,7 +37,7 @@ def test_to_json(example01_text: str) -> None:
     }
 
 
-def test_to_text(example01_json: str) -> None:
+def test_to_text(example01_json: dict[str, Any]) -> None:
     Expr(example01_json).to_text() == "landsat:scene_id = 'LC82030282019133LGN00'"
 
 


### PR DESCRIPTION
## What I am changing

- Adds `parse_text` and `parse_json` allow us to be specific about how we parse, if we already know (e.g. if we have a filter lang)

## Related Issues

- I wanted these methods while implementing https://github.com/developmentseed/tipg/issues/192
