### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-10-14
+
+### Changed
+
+- Use free functions (instead of staticmethods) in the Python API ([#41](https://github.com/developmentseed/cql2-rs/pull/41))
+
 ## [0.2.0] - 2024-10-10
 
 ### Added
@@ -23,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Initial release.
 
-[Unreleased]: https://github.com/developmentseed/cql-rs/compare/v0.2.0...main
+[Unreleased]: https://github.com/developmentseed/cql-rs/compare/v0.3.0...main
+[0.3.0]: https://github.com/developmentseed/cql-rs/releases/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/developmentseed/cql-rs/releases/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/developmentseed/cql-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "cql2"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert-json-diff",
  "boon",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "cql2-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "cql2-python"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "cql2",
@@ -569,9 +569,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
 dependencies = [
  "once_cell",
  "pest",
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ee168e30649f7f234c3d49ef5a7a6cbf5134289bc46c29ff3155fa3221c225"
+checksum = "00e89ce2565d6044ca31a3eb79a334c3a79a841120a98f64eea9f579564cb691"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61cef80755fe9e46bb8a0b8f20752ca7676dcc07a5277d8b7768c6172e529b3"
+checksum = "d8afbaf3abd7325e08f35ffb8deb5892046fcb2608b703db6a583a5ba4cea01e"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce096073ec5405f5ee2b8b31f03a68e02aa10d5d4f565eca04acc41931fa1c"
+checksum = "ec15a5ba277339d04763f4c23d85987a5b08cbb494860be141e6a10a8eb88022"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2440c6d12bc8f3ae39f1e775266fa5122fd0c8891ce7520fa6048e683ad3de28"
+checksum = "15e0f01b5364bcfbb686a52fc4181d412b708a68ed20c330db9fc8d2c2bf5a43"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be962f0e06da8f8465729ea2cb71a416d2257dff56cbe40a70d3e62a93ae5d1"
+checksum = "a09b550200e1e5ed9176976d0060cbc2ea82dc8515da07885e7b8153a85caacb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "wkt"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296937617013271141d1145d9c05861f5ed3b1bc4297e81c692aa3cff9270a9c"
+checksum = "54f7f1ff4ea4c18936d6cd26a6fd24f0003af37e951a8e0e8b9e9a2d0bd0a46d"
 dependencies = [
  "geo-types",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,14 @@
+[workspace.package]
+version = "0.3.0"
+authors = [
+    "David Bitner <bitner@dbspatial.com>",
+    "Pete Gadomski <pete.gadomski@gmail.com>",
+]
+edition = "2021"
+documentation = "https://docs.rs/cql2"
+repository = "https://github.com/developmentseed/cql2-rs"
+license = "MIT"
+
 [package]
 name = "cql2"
 version = { workspace = true }
@@ -31,14 +42,6 @@ rstest = "0.23"
 [workspace]
 default-members = [".", "cli"]
 members = ["cli", "python"]
-
-[workspace.package]
-version = "0.2.0"
-authors = ["David Bitner <bitner@dbspatial.com>"]
-edition = "2021"
-documentation = "https://docs.rs/cql2"
-repository = "https://github.com/developmentseed/cql2-rs"
-license = "MIT"
 
 [workspace.dependencies]
 clap = "4.5"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Parse, validate, and convert [Common Query Language (CQL2)](https://www.ogc.org/
 
 ```toml
 [dependencies]
-cql = "0.2"
+cql = "0.3"
 ```
 
 Then:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["cql2"]
 [dependencies]
 anyhow = "1.0"
 clap = { workspace = true, features = ["derive"] }
-cql2 = { path = "..", version = "0.2.0" }
+cql2 = { path = "..", version = "0.3.0" }
 serde_json = "1.0"
 
 [[bin]]

--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@ Then:
 ```python
 expr = Expr("landsat:scene_id = 'LC82030282019133LGN00'")
 # or
-expr = Expr.from_path("fixtures/text/example01.txt")
+expr = cql2.parse_file("fixtures/text/example01.txt")
 
 s = expr.to_text()
 d = expr.to_json()


### PR DESCRIPTION
It feels _slightly_ weird to release a new 0.X w/o any changes to the rust or cli crates, _but_ I'm going to argue it's ok because

1. we don't expect to release this package too often once it settles, since its problem space is pretty small
2. complexity is much lower when we only have to manage one version for docs, etc

I took the liberty of adding myself to the authors 😊 @kylebarron lmk if you want on there as well.