### PR TITLE
Airectly call signal handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,9 +514,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
@@ -641,18 +641,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e89ce2565d6044ca31a3eb79a334c3a79a841120a98f64eea9f579564cb691"
+checksum = "3d922163ba1f79c04bc49073ba7b32fd5a8d3b76a87c955921234b8e77333c51"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8afbaf3abd7325e08f35ffb8deb5892046fcb2608b703db6a583a5ba4cea01e"
+checksum = "bc38c5feeb496c8321091edf3d63e9a6829eab4b863b4a6a65f26f3e9cc6b179"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec15a5ba277339d04763f4c23d85987a5b08cbb494860be141e6a10a8eb88022"
+checksum = "94845622d88ae274d2729fcefc850e63d7a3ddff5e3ce11bd88486db9f1d357d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e0f01b5364bcfbb686a52fc4181d412b708a68ed20c330db9fc8d2c2bf5a43"
+checksum = "e655aad15e09b94ffdb3ce3d217acf652e26bbc37697ef012f5e5e348c716e5e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a09b550200e1e5ed9176976d0060cbc2ea82dc8515da07885e7b8153a85caacb"
+checksum = "ae1e3f09eecd94618f60a455a23def79f79eba4dc561a97324bf9ac8c6df30ce"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
 dependencies = [
  "indexmap",
  "itoa",

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use pyo3::{
     create_exception,
     exceptions::{PyException, PyIOError, PyValueError},
@@ -9,6 +11,7 @@ create_exception!(cql2, ValidationError, PyException);
 create_exception!(cql2, ParseError, PyException);
 
 /// Crate-specific error enum.
+#[allow(clippy::large_enum_variant)]
 enum Error {
     Cql2(::cql2::Error),
     Pythonize(pythonize::PythonizeError),

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -128,15 +128,15 @@ impl From<pythonize::PythonizeError> for Error {
 fn main(py: Python<'_>) {
     use clap::Parser;
 
-    // https://github.com/PyO3/pyo3/issues/3218
-    py.run_bound(
-        "import signal
-signal.signal(signal.SIGINT, signal.SIG_DFL)",
-        None,
-        None,
-    )
-    .unwrap();
-
+    let signal = py.import_bound("signal").unwrap();
+    signal
+        .getattr("signal")
+        .unwrap()
+        .call1((
+            signal.getattr("SIGINT").unwrap(),
+            signal.getattr("SIG_DFL").unwrap(),
+        ))
+        .unwrap();
     let args: Vec<_> = std::env::args().skip(1).collect();
     ::cql2_cli::Cli::parse_from(args).run()
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 
 /// Crate-specific error enum.
 #[derive(Debug, Error)]
+#[allow(clippy::large_enum_variant)]
 pub enum Error {
     /// [geojson::Error]
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
     unused_qualifications,
     unused_results
 )]
+#![allow(clippy::result_large_err)]
 
 mod error;
 mod expr;


### PR DESCRIPTION
## What I am changing

- Not super-imporant I don't think, but it feels better to use `call1` instead of `run_bound` on some Python code.

## How you can test it

- `maturin develop -m python/Cargo.toml --uv && cql2` then hit ctrl-C