### PR TITLE
release: v0.3.3-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.3.3-alpha.0] - 2024-02-03
+
+### Added
+
+- Match cql2 against JSON ([#55](https://github.com/developmentseed/cql2-rs/pull/55))
+
 ## [0.3.2] - 2024-12-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -218,16 +218,16 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "cql2"
-version = "0.3.2"
+version = "0.3.3-alpha.0"
 dependencies = [
  "assert-json-diff",
  "boon",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "cql2-cli"
-version = "0.3.2"
+version = "0.3.3-alpha.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "cql2-python"
-version = "0.3.2"
+version = "0.3.3-alpha.0"
 dependencies = [
  "clap",
  "cql2",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -784,9 +784,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jiff"
-version = "0.1.24"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bb0c2e28117985a4d90e3bc70092bc8f226f434c7ec7e23dd9ff99c5c5721a"
+checksum = "c04ef77ae73f3cf50510712722f0c4e8b46f5aaa1bf5ffad2ae213e6495e78e5"
 dependencies = [
  "jiff-tzdb-platform",
  "log",
@@ -1267,15 +1267,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1368,9 +1368,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1467,9 +1467,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-normalization"
@@ -1634,9 +1634,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3-alpha.0"
 authors = [
     "David Bitner <bitner@dbspatial.com>",
     "Pete Gadomski <pete.gadomski@gmail.com>",
@@ -28,7 +28,7 @@ geo = "0.29.3"
 geo-types = "0.7.15"
 geojson = "0.24.1"
 geozero = "0.14.0"
-jiff = "0.1.24"
+jiff = "0.1.29"
 json_dotpath = "1.1.0"
 lazy_static = "1.5"
 like = "0.3.1"
@@ -37,7 +37,7 @@ pest_derive = { version = "2.7", features = ["grammar-extras"] }
 pg_escape = "0.1.1"
 serde = "1.0"
 serde_derive = "1.0.217"
-serde_json = { version = "1.0.135", features = ["preserve_order"] }
+serde_json = { version = "1.0.138", features = ["preserve_order"] }
 thiserror = "2.0"
 unaccent = "0.1.0"
 wkt = "0.12.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["cql2"]
 [dependencies]
 anyhow = "1.0"
 clap = { workspace = true, features = ["derive"] }
-cql2 = { path = "..", version = "0.3.0" }
+cql2 = { path = "..", version = "0.3.3-alpha.0" }
 serde_json = "1.0"
 
 [[bin]]


### PR DESCRIPTION
If we want to do a full release, that's fine too, just LMK.

I did a API check and it looks like we're just adding so we should be good to go w/ a non-breaking semver.

<details>
<summary>cargo public-api diff</summary>

```shell
$ cargo public-api diff 0.3.2
Removed items from the public API
=================================
(none)

Changed items in the public API
===============================
(none)

Added items to the public API
=============================
+pub cql2::Error::ExprToBool(cql2::Expr)
+pub cql2::Error::ExprToDateRange(cql2::Expr)
+pub cql2::Error::ExprToF64(cql2::Expr)
+pub cql2::Error::ExprToGeom(cql2::Expr)
+pub cql2::Error::JsonDotpath(json_dotpath::Error)
+pub cql2::Error::Like(like::InvalidPatternError)
+pub cql2::Error::NonReduced()
+pub cql2::Error::OpNotImplemented(&'static str)
+pub cql2::Error::OperationError()
+impl core::convert::From<json_dotpath::Error> for cql2::Error
+pub fn cql2::Error::from(source: json_dotpath::Error) -> Self
+impl core::convert::From<like::InvalidPatternError> for cql2::Error
+pub fn cql2::Error::from(source: like::InvalidPatternError) -> Self
+impl<G1, G2> geo::algorithm::within::Within<G2> for cql2::Error where G2: geo::algorithm::contains::Contains<G1>
+pub fn cql2::Error::is_within(&self, b: &G2) -> bool
+impl<T> crossbeam_epoch::atomic::Pointable for cql2::Error
+pub type cql2::Error::Init = T
+pub const cql2::Error::ALIGN: usize
+pub unsafe fn cql2::Error::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn cql2::Error::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn cql2::Error::drop(ptr: usize)
+pub unsafe fn cql2::Error::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> either::into_either::IntoEither for cql2::Error
+pub fn cql2::Expr::matches(self, j: core::option::Option<&serde_json::value::Value>) -> core::result::Result<bool, cql2::Error>
+pub fn cql2::Expr::reduce(self, j: core::option::Option<&serde_json::value::Value>) -> core::result::Result<cql2::Expr, cql2::Error>
+impl core::cmp::PartialEq for cql2::Expr
+pub fn cql2::Expr::eq(&self, other: &cql2::Expr) -> bool
+impl core::cmp::PartialOrd for cql2::Expr
+pub fn cql2::Expr::partial_cmp(&self, other: &cql2::Expr) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::TryFrom<&cql2::Expr> for bool
+pub type bool::Error = cql2::Error
+pub fn bool::try_from(v: &cql2::Expr) -> core::result::Result<bool, cql2::Error>
+impl core::convert::TryFrom<cql2::Expr> for alloc::string::String
+pub type alloc::string::String::Error = cql2::Error
+pub fn alloc::string::String::try_from(v: cql2::Expr) -> core::result::Result<alloc::string::String, cql2::Error>
+impl core::convert::TryFrom<cql2::Expr> for cql2::DateRange
+impl core::convert::TryFrom<cql2::Expr> for cql2::DateRange
+pub type cql2::DateRange::Error = cql2::Error
+pub type cql2::DateRange::Error = cql2::Error
+pub fn cql2::DateRange::try_from(v: cql2::Expr) -> core::result::Result<cql2::DateRange, cql2::Error>
+pub fn cql2::DateRange::try_from(v: cql2::Expr) -> core::result::Result<cql2::DateRange, cql2::Error>
+impl core::convert::TryFrom<cql2::Expr> for f64
+pub type f64::Error = cql2::Error
+pub fn f64::try_from(v: cql2::Expr) -> core::result::Result<f64, cql2::Error>
+impl core::convert::TryFrom<cql2::Expr> for geo_types::geometry::Geometry
+pub type geo_types::geometry::Geometry::Error = cql2::Error
+pub fn geo_types::geometry::Geometry::try_from(v: cql2::Expr) -> core::result::Result<geo_types::geometry::Geometry, cql2::Error>
+impl core::convert::TryFrom<cql2::Expr> for serde_json::value::Value
+pub type serde_json::value::Value::Error = cql2::Error
+pub fn serde_json::value::Value::try_from(v: cql2::Expr) -> core::result::Result<serde_json::value::Value, cql2::Error>
+impl core::convert::TryFrom<cql2::Expr> for std::collections::hash::set::HashSet<alloc::string::String>
+pub type std::collections::hash::set::HashSet<alloc::string::String>::Error = cql2::Error
+pub fn std::collections::hash::set::HashSet<alloc::string::String>::try_from(v: cql2::Expr) -> core::result::Result<std::collections::hash::set::HashSet<alloc::string::String>, cql2::Error>
+impl core::convert::TryFrom<serde_json::value::Value> for cql2::Expr
+pub type cql2::Expr::Error = cql2::Error
+pub fn cql2::Expr::try_from(v: serde_json::value::Value) -> core::result::Result<cql2::Expr, cql2::Error>
+impl core::marker::StructuralPartialEq for cql2::Expr
+impl<G1, G2> geo::algorithm::within::Within<G2> for cql2::Expr where G2: geo::algorithm::contains::Contains<G1>
+pub fn cql2::Expr::is_within(&self, b: &G2) -> bool
+impl<T> crossbeam_epoch::atomic::Pointable for cql2::Expr
+pub type cql2::Expr::Init = T
+pub const cql2::Expr::ALIGN: usize
+pub unsafe fn cql2::Expr::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn cql2::Expr::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn cql2::Expr::drop(ptr: usize)
+pub unsafe fn cql2::Expr::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> either::into_either::IntoEither for cql2::Expr
+impl core::cmp::PartialEq for cql2::Geometry
+pub fn cql2::Geometry::eq(&self, other: &Self) -> bool
+impl core::cmp::PartialOrd for cql2::Geometry
+pub fn cql2::Geometry::partial_cmp(&self, _other: &Self) -> core::option::Option<core::cmp::Ordering>
+impl<G1, G2> geo::algorithm::within::Within<G2> for cql2::Geometry where G2: geo::algorithm::contains::Contains<G1>
+pub fn cql2::Geometry::is_within(&self, b: &G2) -> bool
+impl<T> crossbeam_epoch::atomic::Pointable for cql2::Geometry
+pub type cql2::Geometry::Init = T
+pub const cql2::Geometry::ALIGN: usize
+pub unsafe fn cql2::Geometry::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn cql2::Geometry::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn cql2::Geometry::drop(ptr: usize)
+pub unsafe fn cql2::Geometry::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> either::into_either::IntoEither for cql2::Geometry
+pub struct cql2::DateRange
+impl core::clone::Clone for cql2::DateRange
+pub fn cql2::DateRange::clone(&self) -> cql2::DateRange
+impl core::cmp::PartialEq for cql2::DateRange
+pub fn cql2::DateRange::eq(&self, other: &cql2::DateRange) -> bool
+impl core::fmt::Debug for cql2::DateRange
+pub fn cql2::DateRange::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for cql2::DateRange
+impl core::marker::Freeze for cql2::DateRange
+impl core::marker::Send for cql2::DateRange
+impl core::marker::Sync for cql2::DateRange
+impl core::marker::Unpin for cql2::DateRange
+impl core::panic::unwind_safe::RefUnwindSafe for cql2::DateRange
+impl core::panic::unwind_safe::UnwindSafe for cql2::DateRange
+impl<G1, G2> geo::algorithm::within::Within<G2> for cql2::DateRange where G2: geo::algorithm::contains::Contains<G1>
+pub fn cql2::DateRange::is_within(&self, b: &G2) -> bool
+impl<T, U> core::convert::Into<U> for cql2::DateRange where U: core::convert::From<T>
+pub fn cql2::DateRange::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for cql2::DateRange where U: core::convert::Into<T>
+pub type cql2::DateRange::Error = core::convert::Infallible
+pub fn cql2::DateRange::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for cql2::DateRange where U: core::convert::TryFrom<T>
+pub type cql2::DateRange::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn cql2::DateRange::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for cql2::DateRange where T: core::clone::Clone
+pub type cql2::DateRange::Owned = T
+pub fn cql2::DateRange::clone_into(&self, target: &mut T)
+pub fn cql2::DateRange::to_owned(&self) -> T
+impl<T> core::any::Any for cql2::DateRange where T: 'static + ?core::marker::Sized
+pub fn cql2::DateRange::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for cql2::DateRange where T: ?core::marker::Sized
+pub fn cql2::DateRange::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for cql2::DateRange where T: ?core::marker::Sized
+pub fn cql2::DateRange::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for cql2::DateRange where T: core::clone::Clone
+pub unsafe fn cql2::DateRange::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for cql2::DateRange
+pub fn cql2::DateRange::from(t: T) -> T
+impl<T> crossbeam_epoch::atomic::Pointable for cql2::DateRange
+pub type cql2::DateRange::Init = T
+pub const cql2::DateRange::ALIGN: usize
+pub unsafe fn cql2::DateRange::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn cql2::DateRange::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn cql2::DateRange::drop(ptr: usize)
+pub unsafe fn cql2::DateRange::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> either::into_either::IntoEither for cql2::DateRange
+impl<T> icu_provider::any::MaybeSendSync for cql2::DateRange
+impl<T> yoke::erased::ErasedDestructor for cql2::DateRange where T: 'static
+impl<G1, G2> geo::algorithm::within::Within<G2> for cql2::SqlQuery where G2: geo::algorithm::contains::Contains<G1>
+pub fn cql2::SqlQuery::is_within(&self, b: &G2) -> bool
+impl<T> crossbeam_epoch::atomic::Pointable for cql2::SqlQuery
+pub type cql2::SqlQuery::Init = T
+pub const cql2::SqlQuery::ALIGN: usize
+pub unsafe fn cql2::SqlQuery::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn cql2::SqlQuery::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn cql2::SqlQuery::drop(ptr: usize)
+pub unsafe fn cql2::SqlQuery::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> either::into_either::IntoEither for cql2::SqlQuery
+impl<G1, G2> geo::algorithm::within::Within<G2> for cql2::Validator where G2: geo::algorithm::contains::Contains<G1>
+pub fn cql2::Validator::is_within(&self, b: &G2) -> bool
+impl<T> crossbeam_epoch::atomic::Pointable for cql2::Validator
+pub type cql2::Validator::Init = T
+pub const cql2::Validator::ALIGN: usize
+pub unsafe fn cql2::Validator::deref<'a>(ptr: usize) -> &'a T
+pub unsafe fn cql2::Validator::deref_mut<'a>(ptr: usize) -> &'a mut T
+pub unsafe fn cql2::Validator::drop(ptr: usize)
+pub unsafe fn cql2::Validator::init(init: <T as crossbeam_epoch::atomic::Pointable>::Init) -> usize
+impl<T> either::into_either::IntoEither for cql2::Validator
+pub fn cql2::spatial_op(left: cql2::Expr, right: cql2::Expr, op: &str) -> core::result::Result<cql2::Expr, cql2::Error>
+pub fn cql2::temporal_op(left_expr: cql2::Expr, right_expr: cql2::Expr, op: &str) -> core::result::Result<cql2::Expr, cql2::Error>
```
</details>
