### PR TITLE
docs: fix instant bug for wasm playground

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,6 @@ site_description: Command-line interface (CLI), Python package, and Rust crate f
 site_author: David Bitner
 repo_name: developmentseed/cql2-rs
 repo_url: https://github.com/developmentseed/cql2-rs
-edit_uri: edit/main/docs/
 
 extra:
   social:
@@ -23,7 +22,6 @@ theme:
   features:
     - content.action.edit
     - navigation.indexes
-    - navigation.instant
     - navigation.tabs
     - navigation.tracking
     - search.share

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,4 +1,23 @@
 # cql2-wasm
-## To Build
-`export RUSTFLAGS='--cfg getrandom_backend="wasm_js'`
-`wasm-pack build`
+
+This is a no-release crate to build a small [WebAssembly](https://webassembly.org/) wrapper for this crate.
+
+## Building
+
+Get [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/).
+Then (from the top-level directory in this repo):
+
+```shell
+scripts/buildwasm
+```
+
+You can then preview our WASM playground locally.
+Get [uv](https://docs.astral.sh/uv/getting-started/installation/), then:
+
+```shell
+uv sync
+uv run mkdocs serve
+```
+
+The playground will be available at <http://127.0.0.1:8000/cql2-rs/playground/>.
+There is a live version available at <http://developmentseed.org/cql2-rs/latest/playground/>.


### PR DESCRIPTION
- Touch up the WASM readme
- Fix the `instant` bug in the playground header link

@bitner want me to do a v0.3.3 release to remove the `alpha` tag after this lands?