### PR TITLE
feat: __add__ and __eq__ functionality in python

### DIFF
--- a/cql2.pyi
+++ b/cql2.pyi
@@ -118,6 +118,22 @@ class Expr:
             ['LC82030282019133LGN00']
         """
 
+    def __add__(self, other: "Expr") -> "Expr":
+        """Combines two cql2 expressions using the AND operator.
+
+        Args:
+            other (Expr): The other expression
+
+        Returns:
+            Expr: The combined expression
+
+        Examples:
+            >>> from cql2 import Expr
+            >>> expr1 = Expr("landsat:scene_id = 'LC82030282019133LGN00'")
+            >>> expr2 = Expr("landsat:cloud_cover = 10")
+            >>> expr = expr1 + expr2
+        """
+
 class SqlQuery:
     """A SQL query"""
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -89,6 +89,10 @@ impl Expr {
     fn __add__(&self, rhs: &Expr) -> Result<Expr> {
         Ok(Expr(self.0.clone() + rhs.0.clone()))
     }
+
+    fn __eq__(&self, rhs: &Expr) -> bool {
+        self.0 == rhs.0
+    }
 }
 
 impl From<::cql2::SqlQuery> for SqlQuery {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -85,6 +85,10 @@ impl Expr {
     fn to_sql(&self) -> Result<SqlQuery> {
         self.0.to_sql().map(SqlQuery::from).map_err(Error::from)
     }
+
+    fn __add__(&self, rhs: &Expr) -> Result<Expr> {
+        Ok(Expr(self.0.clone() + rhs.0.clone()))
+    }
 }
 
 impl From<::cql2::SqlQuery> for SqlQuery {

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -60,4 +60,8 @@ def test_validate() -> None:
 
 
 def test_add() -> None:
-    assert (Expr("True") + Expr("false")).to_text() == Expr("true AND false").to_text()
+    assert Expr("True") + Expr("false") == Expr("true AND false")
+
+
+def test_eq() -> None:
+    assert Expr("True") == Expr("true")

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -57,3 +57,7 @@ def test_validate() -> None:
     )
     with pytest.raises(ValidationError):
         expr.validate()
+
+
+def test_add() -> None:
+    assert (Expr("True") + Expr("false")).to_text() == Expr("true AND false").to_text()

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -7,7 +7,7 @@ use pg_escape::{quote_identifier, quote_literal};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
-use std::ops::Deref;
+use std::ops::{Add, Deref};
 use std::str::FromStr;
 use unaccent::unaccent;
 use wkt::TryFromWkt;
@@ -611,6 +611,42 @@ impl FromStr for Expr {
             crate::parse_json(s).map_err(Error::from)
         } else {
             crate::parse_text(s)
+        }
+    }
+}
+
+impl Add for Expr {
+    type Output = Expr;
+
+    ///
+    /// Combines two expressions with the `+` operator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cql2::Expr;
+    /// use std::ops::Add;
+    ///
+    /// let expr1 = Expr::Bool(true);
+    /// let expr2 = Expr::Bool(false);
+    /// let expected_expr: Expr = "true and false".parse().unwrap();
+    /// assert_eq!(expr1 + expr2, expected_expr);
+    /// ```
+    ///
+    /// ```
+    /// use cql2::Expr;
+    /// use std::ops::Add;
+    ///
+    /// let expr1 = Expr::Bool(true);
+    /// let expr2 = Expr::Bool(false);
+    /// let expected_expr: Expr = "true and false".parse().unwrap();
+    /// assert_eq!(expr1.add(expr2), expected_expr);
+    /// ```
+
+    fn add(self, other: Expr) -> Expr {
+        Expr::Operation {
+            op: "and".to_string(),
+            args: vec![Box::new(self), Box::new(other)],
         }
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -642,7 +642,6 @@ impl Add for Expr {
     /// let expected_expr: Expr = "true and false".parse().unwrap();
     /// assert_eq!(expr1.add(expr2), expected_expr);
     /// ```
-
     fn add(self, other: Expr) -> Expr {
         Expr::Operation {
             op: "and".to_string(),


### PR DESCRIPTION
## What I am changing
- We implement the [Add trait](https://doc.rust-lang.org/std/ops/trait.Add.html) for `Expr` in Rust
- We surface [`__add__`](https://docs.python.org/3/library/operator.html#operator.__add__) and [`__eq__`](https://docs.python.org/3/library/operator.html#operator.__eq__) to Python
