### PR TITLE
Further reductions for and/or

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -7,6 +7,7 @@ use pg_escape::{quote_identifier, quote_literal};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
+use std::fmt::Debug;
 use std::ops::{Add, Deref};
 use std::str::FromStr;
 use unaccent::unaccent;
@@ -173,7 +174,7 @@ impl TryFrom<Expr> for HashSet<String> {
     }
 }
 
-fn cmp_op<T: PartialEq + PartialOrd>(left: T, right: T, op: &str) -> Result<Expr, Error> {
+fn cmp_op<T: PartialEq + PartialOrd + Debug>(left: T, right: T, op: &str) -> Result<Expr, Error> {
     let out = match op {
         "=" => Ok(left == right),
         "<=" => Ok(left <= right),
@@ -245,6 +246,12 @@ impl Expr {
     /// let toexpr: Expr = Expr::from_str("20").unwrap();
     /// assert_eq!(reduced, toexpr);
     ///
+    /// let fromexpr: Expr = Expr::from_str("(bork=1) and (bork=1) and (bork=1 and true)").unwrap();
+    /// let reduced = fromexpr.reduce(Some(&item)).unwrap();
+    /// let toexpr: Expr = Expr::from_str("bork=1 and true").unwrap();
+    /// assert_eq!(reduced, toexpr);
+    ///
+    ///
     /// ```
     pub fn reduce(self, j: Option<&Value>) -> Result<Expr, Error> {
         match self {
@@ -270,19 +277,51 @@ impl Expr {
                     .collect::<Result<_, _>>()?;
 
                 if BOOLOPS.contains(&op.as_str()) {
-                    let bools: Result<Vec<bool>, Error> = args
-                        .iter()
-                        .map(|expr| bool::try_from(expr.as_ref()))
-                        .collect();
-
-                    if let Ok(bools) = bools {
-                        match op.as_str() {
-                            "and" => Ok(Expr::Bool(bools.into_iter().all(|x| x))),
-                            "or" => Ok(Expr::Bool(bools.into_iter().any(|x| x))),
-                            _ => Ok(Expr::Operation { op, args }),
+                    let curop = &op;
+                    let mut dedupargs: Vec<Box<Expr>> = vec![];
+                    let mut nestedargs: Vec<Box<Expr>> = vec![];
+                    for a in args.iter() {
+                        match a.as_ref() {
+                            Expr::Operation { op, args } if op == curop => {
+                                nestedargs.append(&mut args.clone());
+                            }
+                            _ => {
+                                dedupargs.push(a.clone());
+                            }
                         }
+                    }
+                    dedupargs.append(&mut nestedargs);
+                    dedupargs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                    dedupargs.dedup();
+
+                    let mut anytrue: bool = false;
+                    let mut anyfalse: bool = false;
+                    let mut anyexp: bool = false;
+
+                    for a in dedupargs.iter() {
+                        let b = bool::try_from(a.as_ref());
+                        match b {
+                            Ok(true) => {
+                                anytrue = true;
+                            }
+                            Ok(false) => {
+                                anyfalse = true;
+                            }
+                            _ => {
+                                anyexp = true;
+                            }
+                        }
+                    }
+                    dbg!(&op, &anyfalse, &anytrue, &anyexp);
+                    if (op == "and" && anyfalse) || (op == "or" && !anytrue && !anyexp) {
+                        Ok(Expr::Bool(false))
+                    } else if (op == "and" && !anyfalse && !anyexp) || (op == "or" && anytrue) {
+                        Ok(Expr::Bool(true))
                     } else {
-                        Ok(Expr::Operation { op, args })
+                        Ok(Expr::Operation {
+                            op,
+                            args: dedupargs.clone(),
+                        })
                     }
                 } else if op == "not" {
                     match args[0].deref() {
@@ -308,26 +347,30 @@ impl Expr {
                     let left = args[0].deref().clone();
                     let right = args[1].deref().clone();
 
-                    if SPATIALOPS.contains(&op.as_str()) {
-                        Ok(spatial_op(left, right, &op)
-                            .unwrap_or_else(|_| Expr::Operation { op, args }))
-                    } else if TEMPORALOPS.contains(&op.as_str()) {
-                        Ok(temporal_op(left, right, &op)
-                            .unwrap_or_else(|_| Expr::Operation { op, args }))
-                    } else if ARITHOPS.contains(&op.as_str()) {
-                        Ok(arith_op(left, right, &op)
-                            .unwrap_or_else(|_| Expr::Operation { op, args }))
-                    } else if EQOPS.contains(&op.as_str()) || CMPOPS.contains(&op.as_str()) {
-                        Ok(cmp_op(left, right, &op)
-                            .unwrap_or_else(|_| Expr::Operation { op, args }))
-                    } else if ARRAYOPS.contains(&op.as_str()) {
-                        Ok(array_op(left, right, &op)
-                            .unwrap_or_else(|_| Expr::Operation { op, args }))
-                    } else if op == "like" {
-                        let l: String = left.try_into()?;
-                        let r: String = right.try_into()?;
-                        let m: bool = Like::<true>::like(l.as_str(), r.as_str())?;
-                        Ok(Expr::Bool(m))
+                    if std::mem::discriminant(&left) == std::mem::discriminant(&right) {
+                        if SPATIALOPS.contains(&op.as_str()) {
+                            Ok(spatial_op(left, right, &op)
+                                .unwrap_or_else(|_| Expr::Operation { op, args }))
+                        } else if TEMPORALOPS.contains(&op.as_str()) {
+                            Ok(temporal_op(left, right, &op)
+                                .unwrap_or_else(|_| Expr::Operation { op, args }))
+                        } else if ARITHOPS.contains(&op.as_str()) {
+                            Ok(arith_op(left, right, &op)
+                                .unwrap_or_else(|_| Expr::Operation { op, args }))
+                        } else if EQOPS.contains(&op.as_str()) || CMPOPS.contains(&op.as_str()) {
+                            Ok(cmp_op(left, right, &op)
+                                .unwrap_or_else(|_| Expr::Operation { op, args }))
+                        } else if ARRAYOPS.contains(&op.as_str()) {
+                            Ok(array_op(left, right, &op)
+                                .unwrap_or_else(|_| Expr::Operation { op, args }))
+                        } else if op == "like" {
+                            let l: String = left.try_into()?;
+                            let r: String = right.try_into()?;
+                            let m: bool = Like::<true>::like(l.as_str(), r.as_str())?;
+                            Ok(Expr::Bool(m))
+                        } else {
+                            Ok(Expr::Operation { op, args })
+                        }
                     } else if op == "in" {
                         let l: String = left.to_text()?;
                         let r: HashSet<String> = right.try_into()?;

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -314,7 +314,7 @@ impl Expr {
                     }
                     dbg!(&op, &anyfalse, &anytrue, &anyexp);
                     if op == "and" && anytrue {
-                        dedupargs.retain(|x| ! bool::try_from(x.as_ref()).unwrap_or(false));
+                        dedupargs.retain(|x| !bool::try_from(x.as_ref()).unwrap_or(false));
                     }
                     if dedupargs.len() == 1 {
                         Ok(dedupargs.pop().unwrap().as_ref().clone())

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -248,8 +248,7 @@ impl Expr {
     ///
     /// let fromexpr: Expr = Expr::from_str("(bork=1) and (bork=1) and (bork=1 and true)").unwrap();
     /// let reduced = fromexpr.reduce(Some(&item)).unwrap();
-    /// let toexpr: Expr = Expr::from_str("bork=1").unwrap();
-    /// assert_eq!(reduced, toexpr);
+    /// assert_eq!(reduced, "bork=1".parse().unwrap());
     ///
     /// ```
     pub fn reduce(self, j: Option<&Value>) -> Result<Expr, Error> {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -248,7 +248,7 @@ impl Expr {
     ///
     /// let fromexpr: Expr = Expr::from_str("(bork=1) and (bork=1) and (bork=1 and true)").unwrap();
     /// let reduced = fromexpr.reduce(Some(&item)).unwrap();
-    /// let toexpr: Expr = Expr::from_str("bork=1 and true").unwrap();
+    /// let toexpr: Expr = Expr::from_str("bork=1").unwrap();
     /// assert_eq!(reduced, toexpr);
     ///
     ///
@@ -313,7 +313,12 @@ impl Expr {
                         }
                     }
                     dbg!(&op, &anyfalse, &anytrue, &anyexp);
-                    if (op == "and" && anyfalse) || (op == "or" && !anytrue && !anyexp) {
+                    if op == "and" && anytrue {
+                        dedupargs.retain(|x| ! bool::try_from(x.as_ref()).unwrap_or(false));
+                    }
+                    if dedupargs.len() == 1 {
+                        Ok(dedupargs.pop().unwrap().as_ref().clone())
+                    } else if (op == "and" && anyfalse) || (op == "or" && !anytrue && !anyexp) {
                         Ok(Expr::Bool(false))
                     } else if (op == "and" && !anyfalse && !anyexp) || (op == "or" && anytrue) {
                         Ok(Expr::Bool(true))

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -251,7 +251,6 @@ impl Expr {
     /// let toexpr: Expr = Expr::from_str("bork=1").unwrap();
     /// assert_eq!(reduced, toexpr);
     ///
-    ///
     /// ```
     pub fn reduce(self, j: Option<&Value>) -> Result<Expr, Error> {
         match self {

--- a/tests/reduce_tests.rs
+++ b/tests/reduce_tests.rs
@@ -28,6 +28,7 @@ fn validate_reduction(a: String, b: String) {
     let inexpr: Expr = a.parse().unwrap();
     let reduced = inexpr.reduce(Some(&properties)).unwrap();
     let outexpr: Expr = b.parse().unwrap();
+    dbg!(&a, &reduced, &outexpr);
     assert_eq!(reduced, outexpr);
 }
 

--- a/tests/reduce_tests.rs
+++ b/tests/reduce_tests.rs
@@ -28,7 +28,6 @@ fn validate_reduction(a: String, b: String) {
     let inexpr: Expr = a.parse().unwrap();
     let reduced = inexpr.reduce(Some(&properties)).unwrap();
     let outexpr: Expr = b.parse().unwrap();
-    dbg!(&a, &reduced, &outexpr);
     assert_eq!(reduced, outexpr);
 }
 

--- a/tests/reductions.txt
+++ b/tests/reductions.txt
@@ -58,3 +58,11 @@ POINT(0 0) = POINT(0 0)
 true
 POINT(0 0) = POINT(1 0)
 false
+a and b and c and a and a
+a and b and c
+true or b = false
+true
+true or false or c=3
+true
+false or c=3 or c=3
+c=3 or false

--- a/tests/reductions.txt
+++ b/tests/reductions.txt
@@ -66,3 +66,5 @@ true or false or c=3
 true
 false or c=3 or c=3
 c=3 or false
+true and c=3
+c=3

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 
 [[package]]
@@ -205,7 +206,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -223,7 +224,6 @@ wheels = [
 
 [[package]]
 name = "cql2"
-version = "0.3.2"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -496,7 +496,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },


### PR DESCRIPTION
This PR adds further reductions in the case of and/or operations.

- If there are any nested arguments that are of the same operator (and or or), move those arguments up into the higher and/or.
- Remove duplicate expressions from the and/or arguments
- Short circuit and if there are ANY false records for AND, return false.
- Short circuit and if there are ANY true records for OR, return true.
- If the arguments are reduced to a single expression, return just that expression.