### PR TITLE
fix: return error instead of panicing

### DIFF
--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -195,7 +195,7 @@ impl ToDuckSQL for Expr {
                         {
                             format!("{} {} {}", a[0], op, a[1])
                         } else {
-                            unreachable!()
+                            return Err(Error::InvalidOperator(op.to_string()));
                         }
                     }
                 }
@@ -206,12 +206,11 @@ impl ToDuckSQL for Expr {
 
 #[cfg(test)]
 mod tests {
-    use crate::Expr;
-
     use super::ToDuckSQL;
+    use crate::{Error, Expr};
 
     #[test]
-    fn panic() {
+    fn unreachable_code() {
         // https://github.com/stac-utils/rustac-py/issues/135
         let expr: Expr = serde_json::from_value(serde_json::json!({
             "op": "and",
@@ -227,6 +226,9 @@ mod tests {
             ],
         }))
         .unwrap();
-        let _ = expr.to_ducksql().unwrap();
+        assert!(matches!(
+            expr.to_ducksql().unwrap_err(),
+            Error::InvalidOperator(_)
+        ));
     }
 }

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -203,3 +203,30 @@ impl ToDuckSQL for Expr {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Expr;
+
+    use super::ToDuckSQL;
+
+    #[test]
+    fn panic() {
+        // https://github.com/stac-utils/rustac-py/issues/135
+        let expr: Expr = serde_json::from_value(serde_json::json!({
+            "op": "and",
+            "args": [
+                {
+                    "op": "eq",
+                    "args": [{"property": "forecast:horizon"}, "PT48H"]
+                },
+                {
+                    "op": "gte",
+                    "args": [{"property": "forecast:reference_time"}, "2025-05-15T00:00:00Z"]
+                },
+            ],
+        }))
+        .unwrap();
+        let _ = expr.to_ducksql().unwrap();
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,10 @@ pub enum Error {
     #[error("Operator {0} is not implemented for this type.")]
     OpNotImplemented(&'static str),
 
+    /// Invalid operator
+    #[error("{0} is not a valid operator.")]
+    InvalidOperator(String),
+
     /// Expression not reduced to boolean
     #[error("Could not reduce expression to boolean")]
     NonReduced(),


### PR DESCRIPTION
The `eq` operator is from **cql** (not **cql2**, https://github.com/developmentseed/cql2-rs/issues/82) and we panicked, leading to a pretty opaque UX: https://github.com/stac-utils/rustac-py/issues/135. This error should help folks out.