### PR TITLE
feat: use trusted publishing for all releasing

### DIFF
--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -1,0 +1,18 @@
+name: Publish to crates.io
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,52 @@
+name: npm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build WASM package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: "latest"
+      - name: Build WASM for npm
+        run: wasm-pack build --target web --out-dir pkg wasm
+      - name: Upload package
+        uses: actions/upload-artifact@v5
+        with:
+          name: npm-package
+          path: wasm/pkg
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/cql2-wasm
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: npm-package
+          path: package
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "package/*"
+      - name: Publish to npm
+        working-directory: package
+        run: npm publish --provenance --access public

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -148,6 +148,9 @@ jobs:
       id-token: write
       contents: write
       attestations: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/cql2/
     steps:
       - uses: actions/download-artifact@v6
       - name: Generate artifact attestation
@@ -157,8 +160,6 @@ jobs:
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/')
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,15 +1,11 @@
 # Releasing
 
-Setup:
-
-- Install [cargo-release](https://github.com/crate-ci/cargo-release): `cargo install cargo-release`
-
-Then:
-
 1. Create a new branch: `release/vX.Y.Z`
 2. Update the version in `Cargo.toml`
 3. Update the CHANGELOG
 4. Update each README
 5. Open a PR
 6. Once approved, merge the PR
-7. `cargo release -p cql2 --execute`, then `cargo release -p cql2-cli --execute`
+7. `git tag -s vX.Y.Z`
+8. `git push origin vX.Y.Z`
+9. Create a new [release](https://github.com/developmentseed/cql2-rs/releases) for your tag


### PR DESCRIPTION
I've set up trusted publishing for **npm**, **pypi**, and **crates.io**. The **npm** workflow file was mostly Claude-generated, so could contain errors. I've updated the release instructions, as all you need to do now is push a tag.

We should update some READMEs (https://github.com/developmentseed/cql2-rs/issues/108) and do a v0.4.2 to test this, after this PR is approved and merged.

Closes https://github.com/developmentseed/cql2-rs/issues/114