### PR TITLE
fix(ci): remove locked check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
-      - name: Update
-        # Ensure the lockfile is up-to-date, which is required for publishing
-        run: cargo update --locked
       - name: Format
         run: cargo fmt --check
       - name: Check

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
-      - run: cargo publish
+      - run: cargo publish --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This is too strict, as it can fail whenever upstreams change, which means successful PRs can then cause a **main** build to fail. Instead, we allow dirty lockfile when publishing. Original publish error that prompted this is https://github.com/developmentseed/cql2-rs/actions/runs/19311638708/job/55233087403.
