### PR TITLE
fix: remove cargo groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,6 @@ updates:
       interval: "weekly"
   - package-ecosystem: "cargo"
     directory: "/"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
     schedule:
       interval: "weekly"
   - package-ecosystem: "pip"


### PR DESCRIPTION
Seems like they're breaking dependabot?