### PR TITLE
fix: parse bbox into expr

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -125,7 +125,7 @@ impl Cli {
         }
         let input = self
             .input
-            .and_then(|input| if input == "-" { None } else { Some(input) })
+            .filter(|input| input != "-")
             .map(Ok)
             .unwrap_or_else(read_stdin)?;
         let input_format = self.input_format.unwrap_or_else(|| {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -153,6 +153,7 @@ fn parse_expr(expression_pairs: Pairs<'_, Rule>) -> Result<Expr, Error> {
                             .next()
                             .ok_or(Error::MissingArgument("timestamp"))?,
                     }),
+                    "bbox" => Ok(Expr::BBox { bbox: args }),
                     _ => Ok(Expr::Operation { op, args }),
                 }
             }
@@ -334,10 +335,18 @@ fn parse_expr(expression_pairs: Pairs<'_, Rule>) -> Result<Expr, Error> {
 #[cfg(test)]
 mod tests {
     use super::{CQL2Parser, Rule};
+    use crate::Expr;
     use pest::Parser;
 
     #[test]
     fn point_zm() {
         let _ = CQL2Parser::parse(Rule::GEOMETRY, "POINT ZM(-105.1019 40.1672 4981 42)").unwrap();
+    }
+
+    #[test]
+    fn bbox() {
+        let bbox: Expr =
+            super::parse_text("bbox(9.978199, 53.541309, 10.010294, 53.557241)").unwrap();
+        assert!(matches!(bbox, Expr::BBox { .. }));
     }
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -441,4 +441,10 @@ mod tests {
         let sql_str = sql_ast.to_string();
         assert_eq!(sql_str, "ts_start < CAST('2020-02-01' AS DATE)");
     }
+
+    #[test]
+    fn test_bbox() {
+        let expr: Expr = "bbox(1, 2, 3, 4)".parse().unwrap();
+        assert_eq!(expr.to_sql().unwrap(), "st_makeenvelope(1, 2, 3, 4)");
+    }
 }

--- a/tests/expected/example23.txt.out
+++ b/tests/expected/example23.txt.out
@@ -1,3 +1,3 @@
-S_WITHIN(location,BBOX(-118,33.8,-117.9,34)) 
-s_within(location, bbox(-118, 33.8, -117.9, 34))
-{"op":"s_within","args":[{"property":"location"},{"op":"bbox","args":[-118.0,33.8,-117.9,34.0]}]}
+S_WITHIN(location,BBOX(-118,33.8,-117.9,34))
+s_within(location, BBOX(-118, 33.8, -117.9, 34))
+{"op":"s_within","args":[{"property":"location"},{"bbox":[-118.0,33.8,-117.9,34.0]}]}

--- a/tests/expected/example25.txt.out
+++ b/tests/expected/example25.txt.out
@@ -1,3 +1,3 @@
-floors>5 AND S_WITHIN(geometry,BBOX(-118,33.8,-117.9,34)) 
-((floors > 5) AND s_within(geometry, bbox(-118, 33.8, -117.9, 34)))
-{"op":"and","args":[{"op":">","args":[{"property":"floors"},5.0]},{"op":"s_within","args":[{"property":"geometry"},{"op":"bbox","args":[-118.0,33.8,-117.9,34.0]}]}]}
+floors>5 AND S_WITHIN(geometry,BBOX(-118,33.8,-117.9,34))
+((floors > 5) AND s_within(geometry, BBOX(-118, 33.8, -117.9, 34)))
+{"op":"and","args":[{"op":">","args":[{"property":"floors"},5.0]},{"op":"s_within","args":[{"property":"geometry"},{"bbox":[-118.0,33.8,-117.9,34.0]}]}]}

--- a/tests/expected/example45.txt.out
+++ b/tests/expected/example45.txt.out
@@ -1,3 +1,3 @@
-S_INTERSECTS("geometry", BBOX(-128.098193, -1.1, -99999.0, 180.0, 90.0, 100000.0)) 
-s_intersects(geometry, bbox(-128.098193, -1.1, -99999, 180, 90, 100000))
-{"op":"s_intersects","args":[{"property":"geometry"},{"op":"bbox","args":[-128.098193,-1.1,-99999.0,180.0,90.0,100000.0]}]}
+S_INTERSECTS("geometry", BBOX(-128.098193, -1.1, -99999.0, 180.0, 90.0, 100000.0))
+s_intersects(geometry, BBOX(-128.098193, -1.1, -99999, 180, 90, 100000))
+{"op":"s_intersects","args":[{"property":"geometry"},{"bbox":[-128.098193,-1.1,-99999.0,180.0,90.0,100000.0]}]}

--- a/tests/expected/example50.txt.out
+++ b/tests/expected/example50.txt.out
@@ -1,3 +1,3 @@
-S_OVERLAPS("geometry", BBOX(-179.912109, 1.9, 180.0, 16.897016)) 
-s_overlaps(geometry, bbox(-179.912109, 1.9, 180, 16.897016))
-{"op":"s_overlaps","args":[{"property":"geometry"},{"op":"bbox","args":[-179.912109,1.9,180.0,16.897016]}]}
+S_OVERLAPS("geometry", BBOX(-179.912109, 1.9, 180.0, 16.897016))
+s_overlaps(geometry, BBOX(-179.912109, 1.9, 180, 16.897016))
+{"op":"s_overlaps","args":[{"property":"geometry"},{"bbox":[-179.912109,1.9,180.0,16.897016]}]}


### PR DESCRIPTION
Closes #245

Command-line check:

```sh
$ cargo run -- -o sql " s_overlaps(geom,BBox(9.978199, 53.541309, 10.010294, 53.557241))"
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/cql2 -o sql ' s_overlaps(geom,BBox(9.978199, 53.541309, 10.010294, 53.557241))'`
st_overlaps(geom, st_makeenvelope(9.978199, 53.541309, 10.010294, 53.557241))
```